### PR TITLE
fix/validate-assetpath-before-loadobject

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPEditorCommands.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPEditorCommands.cpp
@@ -412,7 +412,19 @@ TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleSpawnBlueprintActor(cons
     }
 
     // Find the blueprint
-    FString AssetPath = TEXT("/Game/Blueprints/") + BlueprintName;
+    if (BlueprintName.IsEmpty())
+    {
+        return FUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Blueprint name is empty"));
+    }
+
+    FString Root      = TEXT("/Game/Blueprints/");
+    FString AssetPath = Root + BlueprintName;
+
+    if (!FPackageName::DoesPackageExist(AssetPath))
+    {
+        return FUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Blueprint '%s' not found – it must reside under /Game/Blueprints"), *BlueprintName));
+    }
+
     UBlueprint* Blueprint = LoadObject<UBlueprint>(nullptr, *AssetPath);
     if (!Blueprint)
     {


### PR DESCRIPTION
Thank you for creating such an amazing project!
While testing, I discovered a bug, so I’m submitting this pull request to address it.

## Description
This PR ensures that the LoadObject function is only called when the AssetPath is valid in the HandleSpawnBlueprintActor method. 

Previously, LoadObject could be invoked even if the file did not exist, potentially leading to runtime errors. 

The updated logic checks the existence of the file using FPaths::FileExists before proceeding with the LoadObject call. If the file does not exist, an appropriate error response is returned, improving the robustness of the blueprint actor spawning process.