### PR TITLE
Make the Blueprint finder smart about name clashes and mixed path formats

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPCommonUtils.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPCommonUtils.cpp
@@ -795,3 +795,21 @@ TArray<FAssetData> FUnrealMCPCommonUtils::FindBlueprintAssets(const FString& Blu
 
     return Matching;
 }
+
+TSharedPtr<FJsonObject> FUnrealMCPCommonUtils::CreateAssetChoicesResponse(const TArray<FAssetData>& MatchingAssets)
+{
+    TArray<TSharedPtr<FJsonValue>> AssetChoices;
+    for (const FAssetData& AssetData : MatchingAssets)
+    {
+        TSharedPtr<FJsonObject> AssetInfo = MakeShared<FJsonObject>();
+        AssetInfo->SetStringField(TEXT("name"), AssetData.AssetName.ToString());
+        AssetInfo->SetStringField(TEXT("path"), AssetData.ObjectPath.ToString());
+        AssetChoices.Add(MakeShared<FJsonValueObject>(AssetInfo));
+    }
+
+    TSharedPtr<FJsonObject> Response = MakeShared<FJsonObject>();
+    Response->SetArrayField(TEXT("choices"), AssetChoices);
+    Response->SetBoolField(TEXT("selection_required"), true);
+    Response->SetStringField(TEXT("message"), TEXT("Multiple matches found. Please select an asset to spawn."));
+    return Response;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPEditorCommands.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPEditorCommands.cpp
@@ -414,11 +414,7 @@ TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleSpawnBlueprintActor(cons
 
     TArray<FAssetData> MatchingAssets = FUnrealMCPCommonUtils::FindBlueprintAssets(BlueprintName);
 
-    if (MatchingAssets.Num() == 0)
-    {
-        return FUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("No matching assets found for '%s'"), *BlueprintName));
-    }
-    else if (MatchingAssets.Num() == 1)
+    if (MatchingAssets.Num() == 1)
     {
         // Single match, proceed to spawn
         FString AssetPath = MatchingAssets[0].GetObjectPathString();
@@ -470,20 +466,10 @@ TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleSpawnBlueprintActor(cons
     }
     else
     {
-        // Multiple matches, ask user to choose
-        TArray<TSharedPtr<FJsonValue>> AssetChoices;
-        for (const FAssetData& AssetData : MatchingAssets)
-        {
-            TSharedPtr<FJsonObject> AssetInfo = MakeShared<FJsonObject>();
-            AssetInfo->SetStringField(TEXT("name"), AssetData.AssetName.ToString());
-            AssetInfo->SetStringField(TEXT("path"), AssetData.ObjectPath.ToString());
-            AssetChoices.Add(MakeShared<FJsonValueObject>(AssetInfo));
-        }
-
-        TSharedPtr<FJsonObject> Response = MakeShared<FJsonObject>();
-        Response->SetArrayField(TEXT("choices"), AssetChoices);
-        return Response;
+        return FUnrealMCPCommonUtils::CreateAssetChoicesResponse(MatchingAssets);
     }
+
+    return FUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("No matching assets found for '%s'"), *BlueprintName));
 }
 
 

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPEditorCommands.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPEditorCommands.cpp
@@ -20,6 +20,7 @@
 #include "Subsystems/EditorActorSubsystem.h"
 #include "Engine/Blueprint.h"
 #include "Engine/BlueprintGeneratedClass.h"
+#include "AssetRegistry/AssetRegistryModule.h"
 
 FUnrealMCPEditorCommands::FUnrealMCPEditorCommands()
 {
@@ -411,67 +412,80 @@ TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleSpawnBlueprintActor(cons
         return FUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'actor_name' parameter"));
     }
 
-    // Find the blueprint
-    if (BlueprintName.IsEmpty())
+    TArray<FAssetData> MatchingAssets = FUnrealMCPCommonUtils::FindBlueprintAssets(BlueprintName);
+
+    if (MatchingAssets.Num() == 0)
     {
-        return FUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Blueprint name is empty"));
+        return FUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("No matching assets found for '%s'"), *BlueprintName));
     }
-
-    FString Root      = TEXT("/Game/Blueprints/");
-    FString AssetPath = Root + BlueprintName;
-
-    if (!FPackageName::DoesPackageExist(AssetPath))
+    else if (MatchingAssets.Num() == 1)
     {
-        return FUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Blueprint '%s' not found – it must reside under /Game/Blueprints"), *BlueprintName));
-    }
+        // Single match, proceed to spawn
+        FString AssetPath = MatchingAssets[0].GetObjectPathString();
+        UBlueprint* Blueprint = LoadObject<UBlueprint>(nullptr, *AssetPath);
+        if (!Blueprint)
+        {
+            return FUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Failed to load Blueprint: %s"), *AssetPath));
+        }
+        
+        // Get transform parameters
+        FVector Location(0.0f, 0.0f, 0.0f);
+        FRotator Rotation(0.0f, 0.0f, 0.0f);
+        FVector Scale(1.0f, 1.0f, 1.0f);
 
-    UBlueprint* Blueprint = LoadObject<UBlueprint>(nullptr, *AssetPath);
-    if (!Blueprint)
+        if (Params->HasField(TEXT("location")))
+        {
+            Location = FUnrealMCPCommonUtils::GetVectorFromJson(Params, TEXT("location"));
+        }
+        if (Params->HasField(TEXT("rotation")))
+        {
+            Rotation = FUnrealMCPCommonUtils::GetRotatorFromJson(Params, TEXT("rotation"));
+        }
+        if (Params->HasField(TEXT("scale")))
+        {
+            Scale = FUnrealMCPCommonUtils::GetVectorFromJson(Params, TEXT("scale"));
+        }
+        // Spawn the actor
+        UWorld* World = GEditor->GetEditorWorldContext().World();
+        if (!World)
+        {
+            return FUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Failed to get editor world"));
+        }
+
+        FTransform SpawnTransform;
+        SpawnTransform.SetLocation(Location);
+        SpawnTransform.SetRotation(FQuat(Rotation));
+        SpawnTransform.SetScale3D(Scale);
+
+        FActorSpawnParameters SpawnParams;
+        SpawnParams.Name = *ActorName;
+
+        AActor* NewActor = World->SpawnActor<AActor>(Blueprint->GeneratedClass, SpawnTransform, SpawnParams);
+        if (NewActor)
+        {
+            return FUnrealMCPCommonUtils::ActorToJsonObject(NewActor, true);
+        }
+
+        return FUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Failed to spawn actor"));
+    }
+    else
     {
-        return FUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Blueprint not found: %s"), *BlueprintName));
+        // Multiple matches, ask user to choose
+        TArray<TSharedPtr<FJsonValue>> AssetChoices;
+        for (const FAssetData& AssetData : MatchingAssets)
+        {
+            TSharedPtr<FJsonObject> AssetInfo = MakeShared<FJsonObject>();
+            AssetInfo->SetStringField(TEXT("name"), AssetData.AssetName.ToString());
+            AssetInfo->SetStringField(TEXT("path"), AssetData.ObjectPath.ToString());
+            AssetChoices.Add(MakeShared<FJsonValueObject>(AssetInfo));
+        }
+
+        TSharedPtr<FJsonObject> Response = MakeShared<FJsonObject>();
+        Response->SetArrayField(TEXT("choices"), AssetChoices);
+        return Response;
     }
-
-    // Get transform parameters
-    FVector Location(0.0f, 0.0f, 0.0f);
-    FRotator Rotation(0.0f, 0.0f, 0.0f);
-    FVector Scale(1.0f, 1.0f, 1.0f);
-
-    if (Params->HasField(TEXT("location")))
-    {
-        Location = FUnrealMCPCommonUtils::GetVectorFromJson(Params, TEXT("location"));
-    }
-    if (Params->HasField(TEXT("rotation")))
-    {
-        Rotation = FUnrealMCPCommonUtils::GetRotatorFromJson(Params, TEXT("rotation"));
-    }
-    if (Params->HasField(TEXT("scale")))
-    {
-        Scale = FUnrealMCPCommonUtils::GetVectorFromJson(Params, TEXT("scale"));
-    }
-
-    // Spawn the actor
-    UWorld* World = GEditor->GetEditorWorldContext().World();
-    if (!World)
-    {
-        return FUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Failed to get editor world"));
-    }
-
-    FTransform SpawnTransform;
-    SpawnTransform.SetLocation(Location);
-    SpawnTransform.SetRotation(FQuat(Rotation));
-    SpawnTransform.SetScale3D(Scale);
-
-    FActorSpawnParameters SpawnParams;
-    SpawnParams.Name = *ActorName;
-
-    AActor* NewActor = World->SpawnActor<AActor>(Blueprint->GeneratedClass, SpawnTransform, SpawnParams);
-    if (NewActor)
-    {
-        return FUnrealMCPCommonUtils::ActorToJsonObject(NewActor, true);
-    }
-
-    return FUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Failed to spawn blueprint actor"));
 }
+
 
 TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleFocusViewport(const TSharedPtr<FJsonObject>& Params)
 {
@@ -597,4 +611,4 @@ TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleTakeScreenshot(const TSh
     }
     
     return FUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Failed to take screenshot"));
-} 
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/UnrealMCPCommonUtils.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/UnrealMCPCommonUtils.h
@@ -2,6 +2,8 @@
 
 #include "CoreMinimal.h"
 #include "Json.h"
+#include "AssetRegistry/AssetData.h"
+#include "Dom/JsonObject.h"
 
 // Forward declarations
 class AActor;
@@ -31,7 +33,8 @@ public:
     static FVector2D GetVector2DFromJson(const TSharedPtr<FJsonObject>& JsonObject, const FString& FieldName);
     static FVector GetVectorFromJson(const TSharedPtr<FJsonObject>& JsonObject, const FString& FieldName);
     static FRotator GetRotatorFromJson(const TSharedPtr<FJsonObject>& JsonObject, const FString& FieldName);
-    
+    static TSharedPtr<FJsonObject> CreateAssetChoicesResponse(const TArray<FAssetData>& MatchingAssets);
+
     // Actor utilities
     static TSharedPtr<FJsonValue> ActorToJson(AActor* Actor);
     static TSharedPtr<FJsonObject> ActorToJsonObject(AActor* Actor, bool bDetailed = false);
@@ -59,4 +62,5 @@ public:
 
     // Asset utilities
     static TArray<FAssetData> FindBlueprintAssets(const FString& BlueprintAssetName);
-}; 
+
+};

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/UnrealMCPCommonUtils.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/UnrealMCPCommonUtils.h
@@ -56,4 +56,7 @@ public:
     // Property utilities
     static bool SetObjectProperty(UObject* Object, const FString& PropertyName, 
                                  const TSharedPtr<FJsonValue>& Value, FString& OutErrorMessage);
+
+    // Asset utilities
+    static TArray<FAssetData> FindBlueprintAssets(const FString& BlueprintAssetName);
 }; 


### PR DESCRIPTION
## Summary & Motivation
Generic LLM agents often supply Blueprint identifiers in inconsistent formats (simple names, package paths, Reference strings, etc.), leading to missed or incorrect spawns—especially when duplicate names exist.  
This patch adds a normalization layer that aims to resolve input paths as accurately as possible across common formats and, when clashes occur, returns clear choices so users can pick the correct asset.

This issue isn’t confined to this tool; it’s a recurring, predictable challenge when building tools for any LLM‑powered agent. I’m opening this PR to propose a solution and refine it together.

## Related Issues
- Addresses #15  
- Addresses #3 – *“Handle two Blueprints with the same name in different folders”*

## Key Changes
| Area | Update |
|------|--------|
| **`FUnrealMCPCommonUtils::FindBlueprintAssets`** | Rewrite: input normalisation, `FARFilter` search confined to `UBlueprint` assets, support for relative/absolute paths |
| **`FUnrealMCPEditorCommands::HandleSpawnBlueprintActor`** | Uses new resolver function; returns: <br>• single match → spawns actor <br>• no match → error JSON <br>• multiple matches → `choices` array for user choice 

## Screenshots – Expected Behavior 

![spawn_bp_1](https://github.com/user-attachments/assets/0dc7340e-03f2-41bf-b096-76fb3a8261ea)
![spawn_bp_2](https://github.com/user-attachments/assets/63c3e9ae-3ccc-4964-a983-7e6d4ebf97cc)
