### PR TITLE
fix/recv buffer ue5.6

### DIFF
--- a/MCPGameProject/MCPGameProject.uproject
+++ b/MCPGameProject/MCPGameProject.uproject
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"EngineAssociation": "5.5",
+	"EngineAssociation": "5.6",
 	"Category": "",
 	"Description": "",
 	"Modules": [

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/MCPServerRunnable.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/MCPServerRunnable.cpp
@@ -11,8 +11,8 @@
 #include "Misc/ScopeLock.h"
 #include "HAL/PlatformTime.h"
 
-// Buffer size for receiving data
-const int32 BufferSize = 8192;
+// Buffer size for receiving data (use internal linkage and unique name to avoid symbol clashes)
+namespace { constexpr int32 MCPReceiveBufferSize = 8192; }
 
 FMCPServerRunnable::FMCPServerRunnable(UUnrealMCPBridge* InBridge, TSharedPtr<FSocket> InListenerSocket)
     : Bridge(InBridge)
@@ -56,11 +56,11 @@ uint32 FMCPServerRunnable::Run()
                 ClientSocket->SetSendBufferSize(SocketBufferSize, SocketBufferSize);
                 ClientSocket->SetReceiveBufferSize(SocketBufferSize, SocketBufferSize);
                 
-                uint8 Buffer[8192];
+                uint8 Buffer[MCPReceiveBufferSize + 1];
                 while (bRunning)
                 {
                     int32 BytesRead = 0;
-                    if (ClientSocket->Recv(Buffer, sizeof(Buffer), BytesRead))
+                    if (ClientSocket->Recv(Buffer, MCPReceiveBufferSize, BytesRead))
                     {
                         if (BytesRead == 0)
                         {
@@ -180,7 +180,7 @@ void FMCPServerRunnable::HandleClientConnection(TSharedPtr<FSocket> InClientSock
     
     // Properly read full message with timeout
     const int32 MaxBufferSize = 4096;
-    uint8 Buffer[MaxBufferSize];
+    uint8 Buffer[MaxBufferSize + 1];
     FString MessageBuffer;
     
     UE_LOG(LogTemp, Display, TEXT("MCPServerRunnable: Starting message receive loop"));


### PR DESCRIPTION
- Project: update EngineAssociation to 5.6
- Networking: avoid potential overflow by sizing recv buffer with extra byte and using named constexpr; recv limited to buffer size; NFC
