### PR TITLE
Add agent add install 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,27 +133,14 @@ Use the following JSON for your mcp configuration based on your MCP client.
 
 An example is found in `mcp.json`
 
-### MCP Configuration Locations
-
-Depending on which MCP client you're using, the configuration file location will differ:
-
-| MCP Client | Configuration File Location | Notes |
-|------------|------------------------------|-------|
-| Claude Desktop | `~/.config/claude-desktop/mcp.json` | On Windows: `%USERPROFILE%\.config\claude-desktop\mcp.json` |
-| Cursor | `.cursor/mcp.json` | Located in your project root directory |
-| Windsurf | `~/.config/windsurf/mcp.json` | On Windows: `%USERPROFILE%\.config\windsurf\mcp.json` |
-
-Each client uses the same JSON format as shown in the example above. 
-Simply place the configuration in the appropriate location for your MCP client.
-
-
-Or use [agent-add](https://github.com/pea3nut/agent-get) to auto-configure any of the above clients (and [15+ more](https://github.com/pea3nut/agent-get)):
+Instead of manually placing this JSON, you can use [agent-add](https://github.com/pea3nut/agent-get) to auto-configure any supported MCP client (Cursor, Claude Desktop, Windsurf, and [15+ more](https://github.com/pea3nut/agent-get)):
 
 ```bash
 npx -y agent-add --mcp '{"unrealMCP":{"command":"uv","args":["--directory","<path/to/unreal-mcp/Python>","run","unreal_mcp_server.py"]}}'
 ```
 
-Replace `<path/to/unreal-mcp/Python>` with the absolute path to this repository's `Python` directory.
+> Requires [Node.js](https://nodejs.org/) 18+. Replace `<path/to/unreal-mcp/Python>` with the absolute path to this repository's `Python` directory.
+
 
 ## License
 MIT

--- a/README.md
+++ b/README.md
@@ -111,17 +111,6 @@ See [Python/README.md](Python/README.md) for detailed Python setup instructions,
 - Running the MCP server
 - Using direct or server-based connections
 
-### Cross-host install via agent-add
-
-Install to any supported AI host (Claude Code, Cursor, Windsurf, and [15+ more](https://github.com/pea3nut/agent-get)) with one command:
-
-```bash
-npx -y agent-add --mcp '{"unrealMCP":{"command":"uv","args":["--directory","<path/to/unreal-mcp/Python>","run","unreal_mcp_server.py"]}}'
-```
-
-> Requires [Node.js](https://nodejs.org/) 18+. Replace `<path/to/unreal-mcp/Python>` with the absolute path to this repository's `Python` directory. `agent-add` auto-detects your AI host and writes the config to the correct location.
-
-
 ### Configuring your MCP Client
 
 Use the following JSON for your mcp configuration based on your MCP client.
@@ -157,6 +146,14 @@ Depending on which MCP client you're using, the configuration file location will
 Each client uses the same JSON format as shown in the example above. 
 Simply place the configuration in the appropriate location for your MCP client.
 
+
+Or use [agent-add](https://github.com/pea3nut/agent-get) to auto-configure any of the above clients (and [15+ more](https://github.com/pea3nut/agent-get)):
+
+```bash
+npx -y agent-add --mcp '{"unrealMCP":{"command":"uv","args":["--directory","<path/to/unreal-mcp/Python>","run","unreal_mcp_server.py"]}}'
+```
+
+Replace `<path/to/unreal-mcp/Python>` with the absolute path to this repository's `Python` directory.
 
 ## License
 MIT

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Use the following JSON for your mcp configuration based on your MCP client.
 
 An example is found in `mcp.json`
 
-Instead of manually placing this JSON, you can use [agent-add](https://github.com/pea3nut/agent-get) to auto-configure any supported MCP client (Cursor, Claude Desktop, Windsurf, and [15+ more](https://github.com/pea3nut/agent-get)):
+Instead of manually placing this JSON, you can use [agent-add](https://github.com/pea3nut/agent-add) to auto-configure any supported MCP client (Cursor, Claude Desktop, Windsurf, and [15+ more](https://github.com/pea3nut/agent-add)):
 
 ```bash
 npx -y agent-add --mcp '{"unrealMCP":{"command":"uv","args":["--directory","<path/to/unreal-mcp/Python>","run","unreal_mcp_server.py"]}}'

--- a/README.md
+++ b/README.md
@@ -111,6 +111,17 @@ See [Python/README.md](Python/README.md) for detailed Python setup instructions,
 - Running the MCP server
 - Using direct or server-based connections
 
+### Cross-host install via agent-add
+
+Install to any supported AI host (Claude Code, Cursor, Windsurf, and [15+ more](https://github.com/pea3nut/agent-get)) with one command:
+
+```bash
+npx -y agent-add --mcp '{"unrealMCP":{"command":"uv","args":["--directory","<path/to/unreal-mcp/Python>","run","unreal_mcp_server.py"]}}'
+```
+
+> Requires [Node.js](https://nodejs.org/) 18+. Replace `<path/to/unreal-mcp/Python>` with the absolute path to this repository's `Python` directory. `agent-add` auto-detects your AI host and writes the config to the correct location.
+
+
 ### Configuring your MCP Client
 
 Use the following JSON for your mcp configuration based on your MCP client.


### PR DESCRIPTION
## Summary

Replaces the "MCP Configuration Locations" table (listing paths for Claude Desktop, Cursor, and Windsurf) with a single [agent-add](https://github.com/pea3nut/agent-get) command that auto-configures any of these clients and 15+ more. The JSON config block is preserved for users who prefer manual setup.

## What changed

- **Removed**: The per-client configuration file paths table
- **Added**: An agent-add command that auto-detects the MCP client and writes the config to the correct location
- **Kept**: The JSON configuration block and all other Quick Start sections unchanged