### PR TITLE
Fix UE 5.6+ compilation and four hardening bugs

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPBlueprintCommands.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPBlueprintCommands.cpp
@@ -194,26 +194,26 @@ TSharedPtr<FJsonObject> FUnrealMCPBlueprintCommands::HandleAddComponentToBluepri
     UClass* ComponentClass = nullptr;
 
     // Try to find the class with exact name first
-    ComponentClass = FindObject<UClass>(ANY_PACKAGE, *ComponentType);
+    ComponentClass = FindFirstObject<UClass>(*ComponentType);
     
     // If not found, try with "Component" suffix
     if (!ComponentClass && !ComponentType.EndsWith(TEXT("Component")))
     {
         FString ComponentTypeWithSuffix = ComponentType + TEXT("Component");
-        ComponentClass = FindObject<UClass>(ANY_PACKAGE, *ComponentTypeWithSuffix);
+        ComponentClass = FindFirstObject<UClass>(*ComponentTypeWithSuffix);
     }
     
     // If still not found, try with "U" prefix
     if (!ComponentClass && !ComponentType.StartsWith(TEXT("U")))
     {
         FString ComponentTypeWithPrefix = TEXT("U") + ComponentType;
-        ComponentClass = FindObject<UClass>(ANY_PACKAGE, *ComponentTypeWithPrefix);
+        ComponentClass = FindFirstObject<UClass>(*ComponentTypeWithPrefix);
         
         // Try with both prefix and suffix
         if (!ComponentClass && !ComponentType.EndsWith(TEXT("Component")))
         {
             FString ComponentTypeWithBoth = TEXT("U") + ComponentType + TEXT("Component");
-            ComponentClass = FindObject<UClass>(ANY_PACKAGE, *ComponentTypeWithBoth);
+            ComponentClass = FindFirstObject<UClass>(*ComponentTypeWithBoth);
         }
     }
     

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPBlueprintCommands.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPBlueprintCommands.cpp
@@ -86,59 +86,27 @@ TSharedPtr<FJsonObject> FUnrealMCPBlueprintCommands::HandleCreateBlueprint(const
 
     // Create the blueprint factory
     UBlueprintFactory* Factory = NewObject<UBlueprintFactory>();
-    
+
     // Handle parent class
     FString ParentClass;
     Params->TryGetStringField(TEXT("parent_class"), ParentClass);
-    
-    // Default to Actor if no parent class specified
+
+    // Default to Actor only when NO parent was requested. A requested-but-unresolved
+    // parent is a hard error — the old silent AActor fallback produced hollow hulls.
     UClass* SelectedParentClass = AActor::StaticClass();
-    
-    // Try to find the specified parent class
     if (!ParentClass.IsEmpty())
     {
-        FString ClassName = ParentClass;
-        if (!ClassName.StartsWith(TEXT("A")))
+        FString ResolveError;
+        UClass* FoundClass = FUnrealMCPCommonUtils::ResolveClassByName(ParentClass, ResolveError);
+        if (!FoundClass)
         {
-            ClassName = TEXT("A") + ClassName;
+            return FUnrealMCPCommonUtils::CreateErrorResponse(
+                FString::Printf(TEXT("Parent class not resolved, blueprint NOT created: %s"), *ResolveError));
         }
-        
-        // First try direct StaticClass lookup for common classes
-        UClass* FoundClass = nullptr;
-        if (ClassName == TEXT("APawn"))
-        {
-            FoundClass = APawn::StaticClass();
-        }
-        else if (ClassName == TEXT("AActor"))
-        {
-            FoundClass = AActor::StaticClass();
-        }
-        else
-        {
-            // Try loading the class using LoadClass which is more reliable than FindObject
-            const FString ClassPath = FString::Printf(TEXT("/Script/Engine.%s"), *ClassName);
-            FoundClass = LoadClass<AActor>(nullptr, *ClassPath);
-            
-            if (!FoundClass)
-            {
-                // Try alternate paths if not found
-                const FString GameClassPath = FString::Printf(TEXT("/Script/Game.%s"), *ClassName);
-                FoundClass = LoadClass<AActor>(nullptr, *GameClassPath);
-            }
-        }
-
-        if (FoundClass)
-        {
-            SelectedParentClass = FoundClass;
-            UE_LOG(LogTemp, Log, TEXT("Successfully set parent class to '%s'"), *ClassName);
-        }
-        else
-        {
-            UE_LOG(LogTemp, Warning, TEXT("Could not find specified parent class '%s' at paths: /Script/Engine.%s or /Script/Game.%s, defaulting to AActor"), 
-                *ClassName, *ClassName, *ClassName);
-        }
+        SelectedParentClass = FoundClass;
+        UE_LOG(LogTemp, Log, TEXT("create_blueprint: parent class '%s' resolved to '%s'"), *ParentClass, *FoundClass->GetPathName());
     }
-    
+
     Factory->ParentClass = SelectedParentClass;
 
     // Create the blueprint
@@ -156,6 +124,7 @@ TSharedPtr<FJsonObject> FUnrealMCPBlueprintCommands::HandleCreateBlueprint(const
         TSharedPtr<FJsonObject> ResultObj = MakeShared<FJsonObject>();
         ResultObj->SetStringField(TEXT("name"), AssetName);
         ResultObj->SetStringField(TEXT("path"), PackagePath + AssetName);
+        ResultObj->SetStringField(TEXT("parent_class"), SelectedParentClass->GetPathName());
         return ResultObj;
     }
 

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPBlueprintNodeCommands.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPBlueprintNodeCommands.cpp
@@ -320,7 +320,7 @@ TSharedPtr<FJsonObject> FUnrealMCPBlueprintNodeCommands::HandleAddBlueprintFunct
         UClass* TargetClass = nullptr;
         
         // First try without a prefix
-        TargetClass = FindObject<UClass>(ANY_PACKAGE, *Target);
+        TargetClass = FindFirstObject<UClass>(*Target);
         UE_LOG(LogTemp, Display, TEXT("Tried to find class '%s': %s"), 
                *Target, TargetClass ? TEXT("Found") : TEXT("Not found"));
         
@@ -328,7 +328,7 @@ TSharedPtr<FJsonObject> FUnrealMCPBlueprintNodeCommands::HandleAddBlueprintFunct
         if (!TargetClass && !Target.StartsWith(TEXT("U")))
         {
             FString TargetWithPrefix = FString(TEXT("U")) + Target;
-            TargetClass = FindObject<UClass>(ANY_PACKAGE, *TargetWithPrefix);
+            TargetClass = FindFirstObject<UClass>(*TargetWithPrefix);
             UE_LOG(LogTemp, Display, TEXT("Tried to find class '%s': %s"), 
                    *TargetWithPrefix, TargetClass ? TEXT("Found") : TEXT("Not found"));
         }
@@ -343,7 +343,7 @@ TSharedPtr<FJsonObject> FUnrealMCPBlueprintNodeCommands::HandleAddBlueprintFunct
             
             for (const FString& ClassName : PossibleClassNames)
             {
-                TargetClass = FindObject<UClass>(ANY_PACKAGE, *ClassName);
+                TargetClass = FindFirstObject<UClass>(*ClassName);
                 if (TargetClass)
                 {
                     UE_LOG(LogTemp, Display, TEXT("Found class using alternative name '%s'"), *ClassName);
@@ -356,7 +356,7 @@ TSharedPtr<FJsonObject> FUnrealMCPBlueprintNodeCommands::HandleAddBlueprintFunct
         if (!TargetClass && Target == TEXT("UGameplayStatics"))
         {
             // For UGameplayStatics, use a direct reference to known class
-            TargetClass = FindObject<UClass>(ANY_PACKAGE, TEXT("UGameplayStatics"));
+            TargetClass = FindFirstObject<UClass>(TEXT("UGameplayStatics"));
             if (!TargetClass)
             {
                 // Try loading it from its known package
@@ -503,7 +503,7 @@ TSharedPtr<FJsonObject> FUnrealMCPBlueprintNodeCommands::HandleAddBlueprintFunct
                             const FString& ClassName = StringVal;
                             
                             // TODO: This likely won't work in UE5.5+, so don't rely on it.
-                            UClass* Class = FindObject<UClass>(ANY_PACKAGE, *ClassName);
+                            UClass* Class = FindFirstObject<UClass>(*ClassName);
 
                             if (!Class)
                             {

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPCommonUtils.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPCommonUtils.cpp
@@ -25,6 +25,7 @@
 #include "BlueprintActionDatabase.h"
 #include "Dom/JsonObject.h"
 #include "Dom/JsonValue.h"
+#include "Misc/PackageName.h"
 
 // JSON Utilities
 TSharedPtr<FJsonObject> FUnrealMCPCommonUtils::CreateErrorResponse(const FString& Message)
@@ -155,6 +156,99 @@ UBlueprint* FUnrealMCPCommonUtils::FindBlueprintByName(const FString& BlueprintN
 {
     FString AssetPath = TEXT("/Game/Blueprints/") + BlueprintName;
     return LoadObject<UBlueprint>(nullptr, *AssetPath);
+}
+
+namespace
+{
+    // REINST_/TRASHCLASS_/SKEL_ classes are compiler leftovers, never valid targets
+    bool IsUsableClass(const UClass* Class)
+    {
+        if (!Class)
+        {
+            return false;
+        }
+        const FString Name = Class->GetName();
+        return !Name.StartsWith(TEXT("REINST_")) &&
+               !Name.StartsWith(TEXT("TRASHCLASS_")) &&
+               !Name.StartsWith(TEXT("SKEL_")) &&
+               !Class->HasAnyClassFlags(CLASS_NewerVersionExists);
+    }
+}
+
+UClass* FUnrealMCPCommonUtils::ResolveClassByName(const FString& InClassName, FString& OutError)
+{
+    const FString ClassName = InClassName.TrimStartAndEnd();
+    if (ClassName.IsEmpty())
+    {
+        OutError = TEXT("Class name is empty");
+        return nullptr;
+    }
+
+    // Full object path: try as class first, then as Blueprint asset
+    if (ClassName.StartsWith(TEXT("/")))
+    {
+        if (UClass* Loaded = LoadObject<UClass>(nullptr, *ClassName))
+        {
+            if (IsUsableClass(Loaded))
+            {
+                return Loaded;
+            }
+        }
+
+        FString AssetPath = ClassName;
+        if (!AssetPath.Contains(TEXT(".")))
+        {
+            AssetPath += TEXT(".") + FPackageName::GetShortName(AssetPath);
+        }
+        if (UBlueprint* BP = LoadObject<UBlueprint>(nullptr, *AssetPath))
+        {
+            if (BP->GeneratedClass && IsUsableClass(BP->GeneratedClass))
+            {
+                return BP->GeneratedClass;
+            }
+        }
+
+        OutError = FString::Printf(TEXT("No class found at path '%s' (tried as UClass and as Blueprint asset)"), *ClassName);
+        return nullptr;
+    }
+
+    // Short name: exact, without A/U prefix, with _C suffix (covers native + loaded BP classes)
+    TArray<FString> Candidates;
+    Candidates.Add(ClassName);
+    if (ClassName.Len() > 1 &&
+        (ClassName[0] == TEXT('A') || ClassName[0] == TEXT('U')) &&
+        FChar::IsUpper(ClassName[1]))
+    {
+        Candidates.Add(ClassName.RightChop(1));
+    }
+    if (!ClassName.EndsWith(TEXT("_C")))
+    {
+        Candidates.Add(ClassName + TEXT("_C"));
+    }
+
+    for (const FString& Candidate : Candidates)
+    {
+        UClass* Found = FindFirstObject<UClass>(*Candidate, EFindFirstObjectOptions::None, ELogVerbosity::NoLogging, TEXT("ResolveClassByName"));
+        if (IsUsableClass(Found))
+        {
+            return Found;
+        }
+    }
+
+    // Unloaded Blueprint under the conventional folder
+    if (UBlueprint* BP = FindBlueprintByName(ClassName))
+    {
+        if (BP->GeneratedClass && IsUsableClass(BP->GeneratedClass))
+        {
+            return BP->GeneratedClass;
+        }
+    }
+
+    OutError = FString::Printf(
+        TEXT("Class '%s' not found. Tried the exact name, without A/U prefix, with '_C', and /Game/Blueprints/%s. ")
+        TEXT("For native classes you can pass a full path like '/Script/MyGame.%s'."),
+        *ClassName, *ClassName, *ClassName);
+    return nullptr;
 }
 
 UEdGraph* FUnrealMCPCommonUtils::FindOrCreateEventGraph(UBlueprint* Blueprint)

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPEditorCommands.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPEditorCommands.cpp
@@ -584,8 +584,8 @@ TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleTakeScreenshot(const TSh
         
         if (Viewport->ReadPixels(Bitmap, FReadSurfaceDataFlags(), ViewportRect))
         {
-            TArray<uint8> CompressedBitmap;
-            FImageUtils::CompressImageArray(Viewport->GetSizeXY().X, Viewport->GetSizeXY().Y, Bitmap, CompressedBitmap);
+            TArray64<uint8> CompressedBitmap;
+            FImageUtils::PNGCompressImageArray(Viewport->GetSizeXY().X, Viewport->GetSizeXY().Y, Bitmap, CompressedBitmap);
             
             if (FFileHelper::SaveArrayToFile(CompressedBitmap, *FilePath))
             {

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPEditorCommands.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPEditorCommands.cpp
@@ -180,6 +180,9 @@ TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleSpawnActor(const TShared
 
     FActorSpawnParameters SpawnParams;
     SpawnParams.Name = *ActorName;
+    // Default NameMode is Required_Fatal: colliding with a not-yet-GC'd (e.g. just
+    // deleted) actor of the same name would hard-crash the whole editor.
+    SpawnParams.NameMode = FActorSpawnParameters::ESpawnActorNameMode::Required_ErrorAndReturnNull;
 
     if (ActorType == TEXT("StaticMeshActor"))
     {
@@ -206,18 +209,20 @@ TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleSpawnActor(const TShared
         return FUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Unknown actor type: %s"), *ActorType));
     }
 
-    if (NewActor)
+    if (!NewActor)
     {
-        // Set scale (since SpawnActor only takes location and rotation)
-        FTransform Transform = NewActor->GetTransform();
-        Transform.SetScale3D(Scale);
-        NewActor->SetActorTransform(Transform);
-
-        // Return the created actor's details
-        return FUnrealMCPCommonUtils::ActorToJsonObject(NewActor, true);
+        return FUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(
+            TEXT("Spawn of '%s' returned null - the name may still be blocked by a previously deleted actor (blocked until GC/editor restart). Use a different name."),
+            *ActorName));
     }
 
-    return FUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Failed to create actor"));
+    // Set scale (since SpawnActor only takes location and rotation)
+    FTransform Transform = NewActor->GetTransform();
+    Transform.SetScale3D(Scale);
+    NewActor->SetActorTransform(Transform);
+
+    // Return the created actor's details
+    return FUnrealMCPCommonUtils::ActorToJsonObject(NewActor, true);
 }
 
 TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleDeleteActor(const TSharedPtr<FJsonObject>& Params)
@@ -463,6 +468,8 @@ TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleSpawnBlueprintActor(cons
 
     FActorSpawnParameters SpawnParams;
     SpawnParams.Name = *ActorName;
+    // See HandleSpawnActor: never let a name collision fatally crash the editor
+    SpawnParams.NameMode = FActorSpawnParameters::ESpawnActorNameMode::Required_ErrorAndReturnNull;
 
     AActor* NewActor = World->SpawnActor<AActor>(Blueprint->GeneratedClass, SpawnTransform, SpawnParams);
     if (NewActor)
@@ -470,7 +477,9 @@ TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleSpawnBlueprintActor(cons
         return FUnrealMCPCommonUtils::ActorToJsonObject(NewActor, true);
     }
 
-    return FUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Failed to spawn blueprint actor"));
+    return FUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(
+        TEXT("Failed to spawn blueprint actor '%s' - the name may still be blocked by a previously deleted actor (blocked until GC/editor restart). Use a different name."),
+        *ActorName));
 }
 
 TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleFocusViewport(const TSharedPtr<FJsonObject>& Params)

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPEditorCommands.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPEditorCommands.cpp
@@ -112,7 +112,9 @@ TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleFindActorsByName(const T
     TArray<TSharedPtr<FJsonValue>> MatchingActors;
     for (AActor* Actor : AllActors)
     {
-        if (Actor && Actor->GetName().Contains(Pattern))
+        // Match the object name AND the editor display label - the outliner shows
+        // labels, and for hand-placed actors the two usually differ
+        if (Actor && (Actor->GetName().Contains(Pattern) || Actor->GetActorLabel().Contains(Pattern)))
         {
             MatchingActors.Add(FUnrealMCPCommonUtils::ActorToJson(Actor));
         }

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/MCPServerRunnable.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/MCPServerRunnable.cpp
@@ -12,7 +12,7 @@
 #include "HAL/PlatformTime.h"
 
 // Buffer size for receiving data
-const int32 BufferSize = 8192;
+const int32 GMCPReceiveBufferSize = 8192;
 
 FMCPServerRunnable::FMCPServerRunnable(UUnrealMCPBridge* InBridge, TSharedPtr<FSocket> InListenerSocket)
     : Bridge(InBridge)

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/UnrealMCPCommonUtils.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/UnrealMCPCommonUtils.h
@@ -39,6 +39,18 @@ public:
     // Blueprint utilities
     static UBlueprint* FindBlueprint(const FString& BlueprintName);
     static UBlueprint* FindBlueprintByName(const FString& BlueprintName);
+
+    /**
+     * Resolve a class from a user-supplied name. Accepts:
+     *  - full object paths:  "/Script/MyGame.MyActor", "/Script/Engine.PlayerStart",
+     *    "/Game/Blueprints/BP_MyActor.BP_MyActor_C" (also without the ".ObjectName" part)
+     *  - short native names with or without prefix: "MyActor", "AMyActor", "PlayerStart"
+     *  - short Blueprint class names: "BP_MyActor" or "BP_MyActor_C" (searched loaded
+     *    classes first, then /Game/Blueprints/<Name>)
+     * Never falls back silently: returns nullptr and fills OutError when unresolved.
+     * REINST_/TRASHCLASS_/SKEL_ classes are skipped.
+     */
+    static UClass* ResolveClassByName(const FString& ClassName, FString& OutError);
     static UEdGraph* FindOrCreateEventGraph(UBlueprint* Blueprint);
     
     // Blueprint node utilities

--- a/Python/tools/editor_tools.py
+++ b/Python/tools/editor_tools.py
@@ -65,10 +65,13 @@ def register_editor_tools(mcp: FastMCP):
             response = unreal.send_command("find_actors_by_name", {
                 "pattern": pattern
             })
-            
+
             if not response:
                 return []
-                
+
+            # The bridge wraps payloads as {"status": ..., "result": {"actors": [...]}}
+            if "result" in response and "actors" in response["result"]:
+                return response["result"]["actors"]
             return response.get("actors", [])
             
         except Exception as e:


### PR DESCRIPTION
## Summary

Four independent bugfixes that make the plugin compile and behave reliably on current engine versions (UE 5.6+). Each fix is a separate commit and can be reviewed in isolation.

Fixes #31, fixes #48, fixes #21.

## Relation to existing PRs

Several open PRs already address parts of the compile breakage: #57 and #45 (`ANY_PACKAGE` / `CompressImageArray`, for 5.5+/5.7) and #33 (receive-buffer constant), plus the 5.7-focused #51/#52/#54/#55. This PR overlaps with those on the compile fixes — consider it an alternative that additionally fixes the three behavioral bugs below (silent `AActor` fallback, name-collision crash, `find_actors_by_name`). Happy to rebase and drop overlapping hunks if you prefer to land one of the other PRs first.

## 1. Compile errors on UE 5.6+

**Problem:** The plugin no longer compiles on UE 5.6 and newer.

**Cause:**
- `FindObject<UClass>(ANY_PACKAGE, ...)` — `ANY_PACKAGE` was deprecated in 5.1 and removed in 5.6 (used in the component and node class lookups).
- The file-local `const int32 BufferSize` in `MCPServerRunnable.cpp` shadows an engine symbol and breaks unity builds.
- `FImageUtils::CompressImageArray` was removed; screenshots failed to build.

**Fix:** Use `FindFirstObject<UClass>`, rename the constant to `GMCPReceiveBufferSize`, and switch `take_screenshot` to `FImageUtils::PNGCompressImageArray` with `TArray64<uint8>`.

## 2. `create_blueprint` silently fell back to `AActor`

**Problem:** Requesting a blueprint with a parent class the resolver could not find (any project C++ class, most engine classes outside `/Script/Engine`, any Blueprint parent) still "succeeded" — but with `AActor` as parent. AI agents kept building on a hollow actor and only noticed much later, when components/logic from the intended parent were missing.

**Cause:** The old lookup only tried `/Script/Engine.<Name>` and `/Script/Game.<Name>`, and on failure logged a warning and defaulted to `AActor`.

**Fix:** New shared resolver `FUnrealMCPCommonUtils::ResolveClassByName` that accepts full object paths (`/Script/Module.Class`, `/Game/...` assets), short native names with or without the `A`/`U` prefix, and Blueprint class names (with or without `_C`), while skipping stale `REINST_`/`TRASHCLASS_`/`SKEL_` classes. If nothing resolves, the command now returns a descriptive error and the blueprint is **not** created. The response also reports the resolved parent class path so clients can verify it.

## 3. Editor crash on actor name collisions

**Problem:** Spawning an actor whose name collides with an existing actor — including a just-deleted actor that has not been garbage-collected yet — crashed the whole editor.

**Cause:** `FActorSpawnParameters::NameMode` defaults to `Required_Fatal`.

**Fix:** `spawn_actor` and `spawn_blueprint_actor` use `Required_ErrorAndReturnNull` and return a descriptive error instead.

## 4. `find_actors_by_name` always returned `[]`

**Problem:** The tool practically never found anything.

**Cause:** Two independent bugs stacked:
- Python: the bridge wraps payloads as `{"status": ..., "result": {"actors": [...]}}`, but the tool read `response["actors"]` at the top level.
- C++: matching only checked the object name (`StaticMeshActor_3`), not the editor display label shown in the World Outliner, so searches by the visible name found nothing.

**Fix:** Unwrap the `result` envelope in Python and match both `GetName()` and `GetActorLabel()` in the plugin.

## How tested

Built and used daily against **UE 5.8** in our own game project (the plugin is dropped into the project's `Plugins/` folder), driven by an MCP client (Claude): created blueprints with engine, project-C++ and Blueprint parents (bad parents now error out instead of producing `AActor` hulls), reproduced the name-collision crash before the fix and verified the error response after it, and verified `find_actors_by_name` returns actors by their outliner labels. Screenshots verified as valid PNG output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
