### PR TITLE
Add editor session, asset and blueprint-reparenting commands

### DIFF
--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPBlueprintCommands.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPBlueprintCommands.cpp
@@ -194,26 +194,26 @@ TSharedPtr<FJsonObject> FUnrealMCPBlueprintCommands::HandleAddComponentToBluepri
     UClass* ComponentClass = nullptr;
 
     // Try to find the class with exact name first
-    ComponentClass = FindObject<UClass>(ANY_PACKAGE, *ComponentType);
+    ComponentClass = FindFirstObject<UClass>(*ComponentType);
     
     // If not found, try with "Component" suffix
     if (!ComponentClass && !ComponentType.EndsWith(TEXT("Component")))
     {
         FString ComponentTypeWithSuffix = ComponentType + TEXT("Component");
-        ComponentClass = FindObject<UClass>(ANY_PACKAGE, *ComponentTypeWithSuffix);
+        ComponentClass = FindFirstObject<UClass>(*ComponentTypeWithSuffix);
     }
     
     // If still not found, try with "U" prefix
     if (!ComponentClass && !ComponentType.StartsWith(TEXT("U")))
     {
         FString ComponentTypeWithPrefix = TEXT("U") + ComponentType;
-        ComponentClass = FindObject<UClass>(ANY_PACKAGE, *ComponentTypeWithPrefix);
+        ComponentClass = FindFirstObject<UClass>(*ComponentTypeWithPrefix);
         
         // Try with both prefix and suffix
         if (!ComponentClass && !ComponentType.EndsWith(TEXT("Component")))
         {
             FString ComponentTypeWithBoth = TEXT("U") + ComponentType + TEXT("Component");
-            ComponentClass = FindObject<UClass>(ANY_PACKAGE, *ComponentTypeWithBoth);
+            ComponentClass = FindFirstObject<UClass>(*ComponentTypeWithBoth);
         }
     }
     

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPBlueprintCommands.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPBlueprintCommands.cpp
@@ -86,59 +86,27 @@ TSharedPtr<FJsonObject> FUnrealMCPBlueprintCommands::HandleCreateBlueprint(const
 
     // Create the blueprint factory
     UBlueprintFactory* Factory = NewObject<UBlueprintFactory>();
-    
+
     // Handle parent class
     FString ParentClass;
     Params->TryGetStringField(TEXT("parent_class"), ParentClass);
-    
-    // Default to Actor if no parent class specified
+
+    // Default to Actor only when NO parent was requested. A requested-but-unresolved
+    // parent is a hard error — the old silent AActor fallback produced hollow hulls.
     UClass* SelectedParentClass = AActor::StaticClass();
-    
-    // Try to find the specified parent class
     if (!ParentClass.IsEmpty())
     {
-        FString ClassName = ParentClass;
-        if (!ClassName.StartsWith(TEXT("A")))
+        FString ResolveError;
+        UClass* FoundClass = FUnrealMCPCommonUtils::ResolveClassByName(ParentClass, ResolveError);
+        if (!FoundClass)
         {
-            ClassName = TEXT("A") + ClassName;
+            return FUnrealMCPCommonUtils::CreateErrorResponse(
+                FString::Printf(TEXT("Parent class not resolved, blueprint NOT created: %s"), *ResolveError));
         }
-        
-        // First try direct StaticClass lookup for common classes
-        UClass* FoundClass = nullptr;
-        if (ClassName == TEXT("APawn"))
-        {
-            FoundClass = APawn::StaticClass();
-        }
-        else if (ClassName == TEXT("AActor"))
-        {
-            FoundClass = AActor::StaticClass();
-        }
-        else
-        {
-            // Try loading the class using LoadClass which is more reliable than FindObject
-            const FString ClassPath = FString::Printf(TEXT("/Script/Engine.%s"), *ClassName);
-            FoundClass = LoadClass<AActor>(nullptr, *ClassPath);
-            
-            if (!FoundClass)
-            {
-                // Try alternate paths if not found
-                const FString GameClassPath = FString::Printf(TEXT("/Script/Game.%s"), *ClassName);
-                FoundClass = LoadClass<AActor>(nullptr, *GameClassPath);
-            }
-        }
-
-        if (FoundClass)
-        {
-            SelectedParentClass = FoundClass;
-            UE_LOG(LogTemp, Log, TEXT("Successfully set parent class to '%s'"), *ClassName);
-        }
-        else
-        {
-            UE_LOG(LogTemp, Warning, TEXT("Could not find specified parent class '%s' at paths: /Script/Engine.%s or /Script/Game.%s, defaulting to AActor"), 
-                *ClassName, *ClassName, *ClassName);
-        }
+        SelectedParentClass = FoundClass;
+        UE_LOG(LogTemp, Log, TEXT("create_blueprint: parent class '%s' resolved to '%s'"), *ParentClass, *FoundClass->GetPathName());
     }
-    
+
     Factory->ParentClass = SelectedParentClass;
 
     // Create the blueprint
@@ -156,6 +124,7 @@ TSharedPtr<FJsonObject> FUnrealMCPBlueprintCommands::HandleCreateBlueprint(const
         TSharedPtr<FJsonObject> ResultObj = MakeShared<FJsonObject>();
         ResultObj->SetStringField(TEXT("name"), AssetName);
         ResultObj->SetStringField(TEXT("path"), PackagePath + AssetName);
+        ResultObj->SetStringField(TEXT("parent_class"), SelectedParentClass->GetPathName());
         return ResultObj;
     }
 

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPBlueprintCommands.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPBlueprintCommands.cpp
@@ -20,6 +20,7 @@
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "GameFramework/Actor.h"
 #include "GameFramework/Pawn.h"
+#include "BlueprintEditorLibrary.h"
 
 FUnrealMCPBlueprintCommands::FUnrealMCPBlueprintCommands()
 {
@@ -63,7 +64,11 @@ TSharedPtr<FJsonObject> FUnrealMCPBlueprintCommands::HandleCommand(const FString
     {
         return HandleSetPawnProperties(Params);
     }
-    
+    else if (CommandType == TEXT("reparent_blueprint"))
+    {
+        return HandleReparentBlueprint(Params);
+    }
+
     return FUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Unknown blueprint command: %s"), *CommandType));
 }
 
@@ -129,6 +134,63 @@ TSharedPtr<FJsonObject> FUnrealMCPBlueprintCommands::HandleCreateBlueprint(const
     }
 
     return FUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Failed to create blueprint"));
+}
+
+TSharedPtr<FJsonObject> FUnrealMCPBlueprintCommands::HandleReparentBlueprint(const TSharedPtr<FJsonObject>& Params)
+{
+    FString BlueprintName;
+    if (!Params->TryGetStringField(TEXT("blueprint_name"), BlueprintName))
+    {
+        return FUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'blueprint_name' parameter"));
+    }
+
+    FString NewParentName;
+    if (!Params->TryGetStringField(TEXT("new_parent_class"), NewParentName))
+    {
+        return FUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'new_parent_class' parameter"));
+    }
+
+    UBlueprint* Blueprint = FUnrealMCPCommonUtils::FindBlueprint(BlueprintName);
+    if (!Blueprint)
+    {
+        return FUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Blueprint not found: %s"), *BlueprintName));
+    }
+
+    FString ResolveError;
+    UClass* NewParentClass = FUnrealMCPCommonUtils::ResolveClassByName(NewParentName, ResolveError);
+    if (!NewParentClass)
+    {
+        return FUnrealMCPCommonUtils::CreateErrorResponse(ResolveError);
+    }
+
+    if (Blueprint->GeneratedClass && NewParentClass->IsChildOf(Blueprint->GeneratedClass))
+    {
+        return FUnrealMCPCommonUtils::CreateErrorResponse(
+            FString::Printf(TEXT("Cannot reparent %s to its own child class %s"), *BlueprintName, *NewParentClass->GetName()));
+    }
+
+    const FString OldParentPath = Blueprint->ParentClass ? Blueprint->ParentClass->GetPathName() : TEXT("None");
+
+    if (Blueprint->ParentClass != NewParentClass)
+    {
+        UBlueprintEditorLibrary::ReparentBlueprint(Blueprint, NewParentClass);
+    }
+
+    // Recompile so placed instances get reinstanced with the new hierarchy
+    FKismetEditorUtilities::CompileBlueprint(Blueprint);
+
+    const bool bCompiledClean = Blueprint->Status == BS_UpToDate || Blueprint->Status == BS_UpToDateWithWarnings;
+
+    TSharedPtr<FJsonObject> ResultObj = MakeShared<FJsonObject>();
+    ResultObj->SetStringField(TEXT("name"), BlueprintName);
+    ResultObj->SetStringField(TEXT("old_parent"), OldParentPath);
+    ResultObj->SetStringField(TEXT("new_parent"), NewParentClass->GetPathName());
+    ResultObj->SetBoolField(TEXT("compiled"), bCompiledClean);
+    if (!bCompiledClean)
+    {
+        ResultObj->SetStringField(TEXT("warning"), TEXT("Blueprint has compile errors after reparenting - open it in the editor to inspect"));
+    }
+    return ResultObj;
 }
 
 TSharedPtr<FJsonObject> FUnrealMCPBlueprintCommands::HandleAddComponentToBlueprint(const TSharedPtr<FJsonObject>& Params)

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPBlueprintNodeCommands.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPBlueprintNodeCommands.cpp
@@ -320,7 +320,7 @@ TSharedPtr<FJsonObject> FUnrealMCPBlueprintNodeCommands::HandleAddBlueprintFunct
         UClass* TargetClass = nullptr;
         
         // First try without a prefix
-        TargetClass = FindObject<UClass>(ANY_PACKAGE, *Target);
+        TargetClass = FindFirstObject<UClass>(*Target);
         UE_LOG(LogTemp, Display, TEXT("Tried to find class '%s': %s"), 
                *Target, TargetClass ? TEXT("Found") : TEXT("Not found"));
         
@@ -328,7 +328,7 @@ TSharedPtr<FJsonObject> FUnrealMCPBlueprintNodeCommands::HandleAddBlueprintFunct
         if (!TargetClass && !Target.StartsWith(TEXT("U")))
         {
             FString TargetWithPrefix = FString(TEXT("U")) + Target;
-            TargetClass = FindObject<UClass>(ANY_PACKAGE, *TargetWithPrefix);
+            TargetClass = FindFirstObject<UClass>(*TargetWithPrefix);
             UE_LOG(LogTemp, Display, TEXT("Tried to find class '%s': %s"), 
                    *TargetWithPrefix, TargetClass ? TEXT("Found") : TEXT("Not found"));
         }
@@ -343,7 +343,7 @@ TSharedPtr<FJsonObject> FUnrealMCPBlueprintNodeCommands::HandleAddBlueprintFunct
             
             for (const FString& ClassName : PossibleClassNames)
             {
-                TargetClass = FindObject<UClass>(ANY_PACKAGE, *ClassName);
+                TargetClass = FindFirstObject<UClass>(*ClassName);
                 if (TargetClass)
                 {
                     UE_LOG(LogTemp, Display, TEXT("Found class using alternative name '%s'"), *ClassName);
@@ -356,7 +356,7 @@ TSharedPtr<FJsonObject> FUnrealMCPBlueprintNodeCommands::HandleAddBlueprintFunct
         if (!TargetClass && Target == TEXT("UGameplayStatics"))
         {
             // For UGameplayStatics, use a direct reference to known class
-            TargetClass = FindObject<UClass>(ANY_PACKAGE, TEXT("UGameplayStatics"));
+            TargetClass = FindFirstObject<UClass>(TEXT("UGameplayStatics"));
             if (!TargetClass)
             {
                 // Try loading it from its known package
@@ -503,7 +503,7 @@ TSharedPtr<FJsonObject> FUnrealMCPBlueprintNodeCommands::HandleAddBlueprintFunct
                             const FString& ClassName = StringVal;
                             
                             // TODO: This likely won't work in UE5.5+, so don't rely on it.
-                            UClass* Class = FindObject<UClass>(ANY_PACKAGE, *ClassName);
+                            UClass* Class = FindFirstObject<UClass>(*ClassName);
 
                             if (!Class)
                             {

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPCommonUtils.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPCommonUtils.cpp
@@ -25,6 +25,7 @@
 #include "BlueprintActionDatabase.h"
 #include "Dom/JsonObject.h"
 #include "Dom/JsonValue.h"
+#include "Misc/PackageName.h"
 
 // JSON Utilities
 TSharedPtr<FJsonObject> FUnrealMCPCommonUtils::CreateErrorResponse(const FString& Message)
@@ -155,6 +156,99 @@ UBlueprint* FUnrealMCPCommonUtils::FindBlueprintByName(const FString& BlueprintN
 {
     FString AssetPath = TEXT("/Game/Blueprints/") + BlueprintName;
     return LoadObject<UBlueprint>(nullptr, *AssetPath);
+}
+
+namespace
+{
+    // REINST_/TRASHCLASS_/SKEL_ classes are compiler leftovers, never valid targets
+    bool IsUsableClass(const UClass* Class)
+    {
+        if (!Class)
+        {
+            return false;
+        }
+        const FString Name = Class->GetName();
+        return !Name.StartsWith(TEXT("REINST_")) &&
+               !Name.StartsWith(TEXT("TRASHCLASS_")) &&
+               !Name.StartsWith(TEXT("SKEL_")) &&
+               !Class->HasAnyClassFlags(CLASS_NewerVersionExists);
+    }
+}
+
+UClass* FUnrealMCPCommonUtils::ResolveClassByName(const FString& InClassName, FString& OutError)
+{
+    const FString ClassName = InClassName.TrimStartAndEnd();
+    if (ClassName.IsEmpty())
+    {
+        OutError = TEXT("Class name is empty");
+        return nullptr;
+    }
+
+    // Full object path: try as class first, then as Blueprint asset
+    if (ClassName.StartsWith(TEXT("/")))
+    {
+        if (UClass* Loaded = LoadObject<UClass>(nullptr, *ClassName))
+        {
+            if (IsUsableClass(Loaded))
+            {
+                return Loaded;
+            }
+        }
+
+        FString AssetPath = ClassName;
+        if (!AssetPath.Contains(TEXT(".")))
+        {
+            AssetPath += TEXT(".") + FPackageName::GetShortName(AssetPath);
+        }
+        if (UBlueprint* BP = LoadObject<UBlueprint>(nullptr, *AssetPath))
+        {
+            if (BP->GeneratedClass && IsUsableClass(BP->GeneratedClass))
+            {
+                return BP->GeneratedClass;
+            }
+        }
+
+        OutError = FString::Printf(TEXT("No class found at path '%s' (tried as UClass and as Blueprint asset)"), *ClassName);
+        return nullptr;
+    }
+
+    // Short name: exact, without A/U prefix, with _C suffix (covers native + loaded BP classes)
+    TArray<FString> Candidates;
+    Candidates.Add(ClassName);
+    if (ClassName.Len() > 1 &&
+        (ClassName[0] == TEXT('A') || ClassName[0] == TEXT('U')) &&
+        FChar::IsUpper(ClassName[1]))
+    {
+        Candidates.Add(ClassName.RightChop(1));
+    }
+    if (!ClassName.EndsWith(TEXT("_C")))
+    {
+        Candidates.Add(ClassName + TEXT("_C"));
+    }
+
+    for (const FString& Candidate : Candidates)
+    {
+        UClass* Found = FindFirstObject<UClass>(*Candidate, EFindFirstObjectOptions::None, ELogVerbosity::NoLogging, TEXT("ResolveClassByName"));
+        if (IsUsableClass(Found))
+        {
+            return Found;
+        }
+    }
+
+    // Unloaded Blueprint under the conventional folder
+    if (UBlueprint* BP = FindBlueprintByName(ClassName))
+    {
+        if (BP->GeneratedClass && IsUsableClass(BP->GeneratedClass))
+        {
+            return BP->GeneratedClass;
+        }
+    }
+
+    OutError = FString::Printf(
+        TEXT("Class '%s' not found. Tried the exact name, without A/U prefix, with '_C', and /Game/Blueprints/%s. ")
+        TEXT("For native classes you can pass a full path like '/Script/MyGame.%s'."),
+        *ClassName, *ClassName, *ClassName);
+    return nullptr;
 }
 
 UEdGraph* FUnrealMCPCommonUtils::FindOrCreateEventGraph(UBlueprint* Blueprint)

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPEditorCommands.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPEditorCommands.cpp
@@ -584,8 +584,8 @@ TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleTakeScreenshot(const TSh
         
         if (Viewport->ReadPixels(Bitmap, FReadSurfaceDataFlags(), ViewportRect))
         {
-            TArray<uint8> CompressedBitmap;
-            FImageUtils::CompressImageArray(Viewport->GetSizeXY().X, Viewport->GetSizeXY().Y, Bitmap, CompressedBitmap);
+            TArray64<uint8> CompressedBitmap;
+            FImageUtils::PNGCompressImageArray(Viewport->GetSizeXY().X, Viewport->GetSizeXY().Y, Bitmap, CompressedBitmap);
             
             if (FFileHelper::SaveArrayToFile(CompressedBitmap, *FilePath))
             {

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPEditorCommands.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPEditorCommands.cpp
@@ -20,6 +20,9 @@
 #include "Subsystems/EditorActorSubsystem.h"
 #include "Engine/Blueprint.h"
 #include "Engine/BlueprintGeneratedClass.h"
+#include "FileHelpers.h"
+#include "Settings/LevelEditorPlaySettings.h"
+#include "EditorAssetLibrary.h"
 
 FUnrealMCPEditorCommands::FUnrealMCPEditorCommands()
 {
@@ -74,7 +77,37 @@ TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleCommand(const FString& C
     {
         return HandleTakeScreenshot(Params);
     }
-    
+    // Level / session commands
+    else if (CommandType == TEXT("save_all"))
+    {
+        return HandleSaveAll(Params);
+    }
+    else if (CommandType == TEXT("start_pie"))
+    {
+        return HandleStartPie(Params);
+    }
+    else if (CommandType == TEXT("stop_pie"))
+    {
+        return HandleStopPie(Params);
+    }
+    else if (CommandType == TEXT("exec_console_command"))
+    {
+        return HandleExecConsoleCommand(Params);
+    }
+    // Asset commands
+    else if (CommandType == TEXT("list_assets"))
+    {
+        return HandleListAssets(Params);
+    }
+    else if (CommandType == TEXT("asset_exists"))
+    {
+        return HandleAssetExists(Params);
+    }
+    else if (CommandType == TEXT("delete_asset"))
+    {
+        return HandleDeleteAsset(Params);
+    }
+
     return FUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Unknown editor command: %s"), *CommandType));
 }
 
@@ -186,31 +219,47 @@ TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleSpawnActor(const TShared
     // deleted) actor of the same name would hard-crash the whole editor.
     SpawnParams.NameMode = FActorSpawnParameters::ESpawnActorNameMode::Required_ErrorAndReturnNull;
 
+    // Well-known shortcuts first, anything else through the generic class resolver
+    UClass* SpawnClass = nullptr;
     if (ActorType == TEXT("StaticMeshActor"))
     {
-        NewActor = World->SpawnActor<AStaticMeshActor>(AStaticMeshActor::StaticClass(), Location, Rotation, SpawnParams);
+        SpawnClass = AStaticMeshActor::StaticClass();
     }
     else if (ActorType == TEXT("PointLight"))
     {
-        NewActor = World->SpawnActor<APointLight>(APointLight::StaticClass(), Location, Rotation, SpawnParams);
+        SpawnClass = APointLight::StaticClass();
     }
     else if (ActorType == TEXT("SpotLight"))
     {
-        NewActor = World->SpawnActor<ASpotLight>(ASpotLight::StaticClass(), Location, Rotation, SpawnParams);
+        SpawnClass = ASpotLight::StaticClass();
     }
     else if (ActorType == TEXT("DirectionalLight"))
     {
-        NewActor = World->SpawnActor<ADirectionalLight>(ADirectionalLight::StaticClass(), Location, Rotation, SpawnParams);
+        SpawnClass = ADirectionalLight::StaticClass();
     }
     else if (ActorType == TEXT("CameraActor"))
     {
-        NewActor = World->SpawnActor<ACameraActor>(ACameraActor::StaticClass(), Location, Rotation, SpawnParams);
+        SpawnClass = ACameraActor::StaticClass();
     }
     else
     {
-        return FUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Unknown actor type: %s"), *ActorType));
+        FString ResolveError;
+        SpawnClass = FUnrealMCPCommonUtils::ResolveClassByName(ActorType, ResolveError);
+        if (!SpawnClass)
+        {
+            return FUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Unknown actor type '%s': %s"), *ActorType, *ResolveError));
+        }
+        if (!SpawnClass->IsChildOf(AActor::StaticClass()))
+        {
+            return FUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Class '%s' is not an Actor class"), *SpawnClass->GetPathName()));
+        }
+        if (SpawnClass->HasAnyClassFlags(CLASS_Abstract | CLASS_Deprecated))
+        {
+            return FUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Class '%s' is abstract or deprecated and cannot be spawned"), *SpawnClass->GetPathName()));
+        }
     }
 
+    NewActor = World->SpawnActor<AActor>(SpawnClass, Location, Rotation, SpawnParams);
     if (!NewActor)
     {
         return FUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(
@@ -608,4 +657,181 @@ TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleTakeScreenshot(const TSh
     }
     
     return FUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Failed to take screenshot"));
-} 
+}
+
+TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleSaveAll(const TSharedPtr<FJsonObject>& Params)
+{
+    // Silent save of every dirty package (maps + assets). bFastSave also skips
+    // source-control checkout dialogs - a modal on the GameThread would stall
+    // the bridge past the client timeout.
+    const bool bSaved = FEditorFileUtils::SaveDirtyPackages(
+        /*bPromptUserToSave=*/false,
+        /*bSaveMapPackages=*/true,
+        /*bSaveContentPackages=*/true,
+        /*bFastSave=*/true);
+
+    TSharedPtr<FJsonObject> ResultObj = MakeShared<FJsonObject>();
+    ResultObj->SetBoolField(TEXT("saved"), bSaved);
+    return ResultObj;
+}
+
+TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleStartPie(const TSharedPtr<FJsonObject>& Params)
+{
+    if (!GEditor)
+    {
+        return FUnrealMCPCommonUtils::CreateErrorResponse(TEXT("GEditor is not available"));
+    }
+    if (GEditor->PlayWorld)
+    {
+        return FUnrealMCPCommonUtils::CreateErrorResponse(TEXT("A PIE session is already running - call stop_pie first"));
+    }
+
+    int32 NumPlayers = 1;
+    if (Params->HasField(TEXT("num_players")))
+    {
+        NumPlayers = FMath::Clamp(static_cast<int32>(Params->GetNumberField(TEXT("num_players"))), 1, 4);
+    }
+
+    FString NetModeString = TEXT("standalone");
+    Params->TryGetStringField(TEXT("net_mode"), NetModeString);
+
+    EPlayNetMode NetMode = EPlayNetMode::PIE_Standalone;
+    if (NetModeString == TEXT("listen") || NetModeString == TEXT("listen_server"))
+    {
+        NetMode = EPlayNetMode::PIE_ListenServer;
+    }
+    else if (NetModeString == TEXT("client"))
+    {
+        NetMode = EPlayNetMode::PIE_Client;
+    }
+    else if (NetModeString != TEXT("standalone"))
+    {
+        return FUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(
+            TEXT("Unknown net_mode '%s' (use 'standalone', 'listen' or 'client')"), *NetModeString));
+    }
+
+    // The PIE request reads the play-settings default object - same path the toolbar uses
+    ULevelEditorPlaySettings* PlaySettings = GetMutableDefault<ULevelEditorPlaySettings>();
+    PlaySettings->SetPlayNumberOfClients(NumPlayers);
+    PlaySettings->SetPlayNetMode(NetMode);
+
+    FRequestPlaySessionParams SessionParams;
+    GEditor->RequestPlaySession(SessionParams);
+
+    TSharedPtr<FJsonObject> ResultObj = MakeShared<FJsonObject>();
+    ResultObj->SetBoolField(TEXT("requested"), true);
+    ResultObj->SetNumberField(TEXT("num_players"), NumPlayers);
+    ResultObj->SetStringField(TEXT("net_mode"), NetModeString);
+    ResultObj->SetStringField(TEXT("note"), TEXT("PIE starts on the next editor tick - poll the log or stop_pie when done"));
+    return ResultObj;
+}
+
+TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleStopPie(const TSharedPtr<FJsonObject>& Params)
+{
+    if (!GEditor)
+    {
+        return FUnrealMCPCommonUtils::CreateErrorResponse(TEXT("GEditor is not available"));
+    }
+
+    const bool bWasPlaying = GEditor->PlayWorld != nullptr;
+    if (bWasPlaying)
+    {
+        GEditor->RequestEndPlayMap();
+    }
+
+    TSharedPtr<FJsonObject> ResultObj = MakeShared<FJsonObject>();
+    ResultObj->SetBoolField(TEXT("was_playing"), bWasPlaying);
+    return ResultObj;
+}
+
+TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleExecConsoleCommand(const TSharedPtr<FJsonObject>& Params)
+{
+    FString Command;
+    if (!Params->TryGetStringField(TEXT("command"), Command) || Command.TrimStartAndEnd().IsEmpty())
+    {
+        return FUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'command' parameter"));
+    }
+
+    if (!GEditor || !GEngine)
+    {
+        return FUnrealMCPCommonUtils::CreateErrorResponse(TEXT("GEditor/GEngine are not available"));
+    }
+
+    // Prefer the running PIE world so gameplay cvars/exec commands land in the game
+    UWorld* TargetWorld = GEditor->PlayWorld ? GEditor->PlayWorld.Get() : GEditor->GetEditorWorldContext().World();
+    if (!TargetWorld)
+    {
+        return FUnrealMCPCommonUtils::CreateErrorResponse(TEXT("No world available to execute the command in"));
+    }
+
+    const bool bHandled = GEngine->Exec(TargetWorld, *Command);
+
+    TSharedPtr<FJsonObject> ResultObj = MakeShared<FJsonObject>();
+    ResultObj->SetStringField(TEXT("command"), Command);
+    ResultObj->SetBoolField(TEXT("handled"), bHandled);
+    ResultObj->SetStringField(TEXT("world"), TargetWorld->GetName());
+    return ResultObj;
+}
+
+TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleListAssets(const TSharedPtr<FJsonObject>& Params)
+{
+    FString Directory = TEXT("/Game");
+    Params->TryGetStringField(TEXT("directory"), Directory);
+
+    bool bRecursive = true;
+    if (Params->HasField(TEXT("recursive")))
+    {
+        bRecursive = Params->GetBoolField(TEXT("recursive"));
+    }
+
+    const TArray<FString> AssetPaths = UEditorAssetLibrary::ListAssets(Directory, bRecursive, /*bIncludeFolder=*/false);
+
+    TArray<TSharedPtr<FJsonValue>> AssetArray;
+    for (const FString& AssetPath : AssetPaths)
+    {
+        AssetArray.Add(MakeShared<FJsonValueString>(AssetPath));
+    }
+
+    TSharedPtr<FJsonObject> ResultObj = MakeShared<FJsonObject>();
+    ResultObj->SetStringField(TEXT("directory"), Directory);
+    ResultObj->SetArrayField(TEXT("assets"), AssetArray);
+    return ResultObj;
+}
+
+TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleAssetExists(const TSharedPtr<FJsonObject>& Params)
+{
+    FString AssetPath;
+    if (!Params->TryGetStringField(TEXT("asset_path"), AssetPath))
+    {
+        return FUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'asset_path' parameter"));
+    }
+
+    TSharedPtr<FJsonObject> ResultObj = MakeShared<FJsonObject>();
+    ResultObj->SetStringField(TEXT("asset_path"), AssetPath);
+    ResultObj->SetBoolField(TEXT("exists"), UEditorAssetLibrary::DoesAssetExist(AssetPath));
+    return ResultObj;
+}
+
+TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleDeleteAsset(const TSharedPtr<FJsonObject>& Params)
+{
+    FString AssetPath;
+    if (!Params->TryGetStringField(TEXT("asset_path"), AssetPath))
+    {
+        return FUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Missing 'asset_path' parameter"));
+    }
+
+    if (!UEditorAssetLibrary::DoesAssetExist(AssetPath))
+    {
+        return FUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Asset does not exist: %s"), *AssetPath));
+    }
+
+    const bool bDeleted = UEditorAssetLibrary::DeleteAsset(AssetPath);
+    if (!bDeleted)
+    {
+        return FUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Failed to delete asset: %s"), *AssetPath));
+    }
+
+    TSharedPtr<FJsonObject> ResultObj = MakeShared<FJsonObject>();
+    ResultObj->SetStringField(TEXT("deleted_asset"), AssetPath);
+    return ResultObj;
+}

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPEditorCommands.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPEditorCommands.cpp
@@ -180,6 +180,9 @@ TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleSpawnActor(const TShared
 
     FActorSpawnParameters SpawnParams;
     SpawnParams.Name = *ActorName;
+    // Default NameMode is Required_Fatal: colliding with a not-yet-GC'd (e.g. just
+    // deleted) actor of the same name would hard-crash the whole editor.
+    SpawnParams.NameMode = FActorSpawnParameters::ESpawnActorNameMode::Required_ErrorAndReturnNull;
 
     if (ActorType == TEXT("StaticMeshActor"))
     {
@@ -206,18 +209,20 @@ TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleSpawnActor(const TShared
         return FUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(TEXT("Unknown actor type: %s"), *ActorType));
     }
 
-    if (NewActor)
+    if (!NewActor)
     {
-        // Set scale (since SpawnActor only takes location and rotation)
-        FTransform Transform = NewActor->GetTransform();
-        Transform.SetScale3D(Scale);
-        NewActor->SetActorTransform(Transform);
-
-        // Return the created actor's details
-        return FUnrealMCPCommonUtils::ActorToJsonObject(NewActor, true);
+        return FUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(
+            TEXT("Spawn of '%s' returned null - the name may still be blocked by a previously deleted actor (blocked until GC/editor restart). Use a different name."),
+            *ActorName));
     }
 
-    return FUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Failed to create actor"));
+    // Set scale (since SpawnActor only takes location and rotation)
+    FTransform Transform = NewActor->GetTransform();
+    Transform.SetScale3D(Scale);
+    NewActor->SetActorTransform(Transform);
+
+    // Return the created actor's details
+    return FUnrealMCPCommonUtils::ActorToJsonObject(NewActor, true);
 }
 
 TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleDeleteActor(const TSharedPtr<FJsonObject>& Params)
@@ -463,6 +468,8 @@ TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleSpawnBlueprintActor(cons
 
     FActorSpawnParameters SpawnParams;
     SpawnParams.Name = *ActorName;
+    // See HandleSpawnActor: never let a name collision fatally crash the editor
+    SpawnParams.NameMode = FActorSpawnParameters::ESpawnActorNameMode::Required_ErrorAndReturnNull;
 
     AActor* NewActor = World->SpawnActor<AActor>(Blueprint->GeneratedClass, SpawnTransform, SpawnParams);
     if (NewActor)
@@ -470,7 +477,9 @@ TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleSpawnBlueprintActor(cons
         return FUnrealMCPCommonUtils::ActorToJsonObject(NewActor, true);
     }
 
-    return FUnrealMCPCommonUtils::CreateErrorResponse(TEXT("Failed to spawn blueprint actor"));
+    return FUnrealMCPCommonUtils::CreateErrorResponse(FString::Printf(
+        TEXT("Failed to spawn blueprint actor '%s' - the name may still be blocked by a previously deleted actor (blocked until GC/editor restart). Use a different name."),
+        *ActorName));
 }
 
 TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleFocusViewport(const TSharedPtr<FJsonObject>& Params)

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPEditorCommands.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/Commands/UnrealMCPEditorCommands.cpp
@@ -112,7 +112,9 @@ TSharedPtr<FJsonObject> FUnrealMCPEditorCommands::HandleFindActorsByName(const T
     TArray<TSharedPtr<FJsonValue>> MatchingActors;
     for (AActor* Actor : AllActors)
     {
-        if (Actor && Actor->GetName().Contains(Pattern))
+        // Match the object name AND the editor display label - the outliner shows
+        // labels, and for hand-placed actors the two usually differ
+        if (Actor && (Actor->GetName().Contains(Pattern) || Actor->GetActorLabel().Contains(Pattern)))
         {
             MatchingActors.Add(FUnrealMCPCommonUtils::ActorToJson(Actor));
         }

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/MCPServerRunnable.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/MCPServerRunnable.cpp
@@ -12,7 +12,7 @@
 #include "HAL/PlatformTime.h"
 
 // Buffer size for receiving data
-const int32 BufferSize = 8192;
+const int32 GMCPReceiveBufferSize = 8192;
 
 FMCPServerRunnable::FMCPServerRunnable(UUnrealMCPBridge* InBridge, TSharedPtr<FSocket> InListenerSocket)
     : Bridge(InBridge)

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/UnrealMCPBridge.cpp
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Private/UnrealMCPBridge.cpp
@@ -233,8 +233,15 @@ FString UUnrealMCPBridge::ExecuteCommand(const FString& CommandType, const TShar
                      CommandType == TEXT("get_actor_properties") ||
                      CommandType == TEXT("set_actor_property") ||
                      CommandType == TEXT("spawn_blueprint_actor") ||
-                     CommandType == TEXT("focus_viewport") || 
-                     CommandType == TEXT("take_screenshot"))
+                     CommandType == TEXT("focus_viewport") ||
+                     CommandType == TEXT("take_screenshot") ||
+                     CommandType == TEXT("save_all") ||
+                     CommandType == TEXT("start_pie") ||
+                     CommandType == TEXT("stop_pie") ||
+                     CommandType == TEXT("exec_console_command") ||
+                     CommandType == TEXT("list_assets") ||
+                     CommandType == TEXT("asset_exists") ||
+                     CommandType == TEXT("delete_asset"))
             {
                 ResultJson = EditorCommands->HandleCommand(CommandType, Params);
             }
@@ -246,7 +253,8 @@ FString UUnrealMCPBridge::ExecuteCommand(const FString& CommandType, const TShar
                      CommandType == TEXT("compile_blueprint") || 
                      CommandType == TEXT("set_blueprint_property") || 
                      CommandType == TEXT("set_static_mesh_properties") ||
-                     CommandType == TEXT("set_pawn_properties"))
+                     CommandType == TEXT("set_pawn_properties") ||
+                     CommandType == TEXT("reparent_blueprint"))
             {
                 ResultJson = BlueprintCommands->HandleCommand(CommandType, Params);
             }

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/UnrealMCPBlueprintCommands.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/UnrealMCPBlueprintCommands.h
@@ -25,6 +25,7 @@ private:
     TSharedPtr<FJsonObject> HandleSetBlueprintProperty(const TSharedPtr<FJsonObject>& Params);
     TSharedPtr<FJsonObject> HandleSetStaticMeshProperties(const TSharedPtr<FJsonObject>& Params);
     TSharedPtr<FJsonObject> HandleSetPawnProperties(const TSharedPtr<FJsonObject>& Params);
+    TSharedPtr<FJsonObject> HandleReparentBlueprint(const TSharedPtr<FJsonObject>& Params);
 
     // Helper functions
     TSharedPtr<FJsonObject> AddComponentToBlueprint(const FString& BlueprintName, const FString& ComponentType, 

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/UnrealMCPCommonUtils.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/UnrealMCPCommonUtils.h
@@ -39,6 +39,18 @@ public:
     // Blueprint utilities
     static UBlueprint* FindBlueprint(const FString& BlueprintName);
     static UBlueprint* FindBlueprintByName(const FString& BlueprintName);
+
+    /**
+     * Resolve a class from a user-supplied name. Accepts:
+     *  - full object paths:  "/Script/MyGame.MyActor", "/Script/Engine.PlayerStart",
+     *    "/Game/Blueprints/BP_MyActor.BP_MyActor_C" (also without the ".ObjectName" part)
+     *  - short native names with or without prefix: "MyActor", "AMyActor", "PlayerStart"
+     *  - short Blueprint class names: "BP_MyActor" or "BP_MyActor_C" (searched loaded
+     *    classes first, then /Game/Blueprints/<Name>)
+     * Never falls back silently: returns nullptr and fills OutError when unresolved.
+     * REINST_/TRASHCLASS_/SKEL_ classes are skipped.
+     */
+    static UClass* ResolveClassByName(const FString& ClassName, FString& OutError);
     static UEdGraph* FindOrCreateEventGraph(UBlueprint* Blueprint);
     
     // Blueprint node utilities

--- a/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/UnrealMCPEditorCommands.h
+++ b/MCPGameProject/Plugins/UnrealMCP/Source/UnrealMCP/Public/Commands/UnrealMCPEditorCommands.h
@@ -31,4 +31,15 @@ private:
     // Editor viewport commands
     TSharedPtr<FJsonObject> HandleFocusViewport(const TSharedPtr<FJsonObject>& Params);
     TSharedPtr<FJsonObject> HandleTakeScreenshot(const TSharedPtr<FJsonObject>& Params);
-}; 
+
+    // Level / session commands
+    TSharedPtr<FJsonObject> HandleSaveAll(const TSharedPtr<FJsonObject>& Params);
+    TSharedPtr<FJsonObject> HandleStartPie(const TSharedPtr<FJsonObject>& Params);
+    TSharedPtr<FJsonObject> HandleStopPie(const TSharedPtr<FJsonObject>& Params);
+    TSharedPtr<FJsonObject> HandleExecConsoleCommand(const TSharedPtr<FJsonObject>& Params);
+
+    // Asset commands
+    TSharedPtr<FJsonObject> HandleListAssets(const TSharedPtr<FJsonObject>& Params);
+    TSharedPtr<FJsonObject> HandleAssetExists(const TSharedPtr<FJsonObject>& Params);
+    TSharedPtr<FJsonObject> HandleDeleteAsset(const TSharedPtr<FJsonObject>& Params);
+};

--- a/Python/tools/blueprint_tools.py
+++ b/Python/tools/blueprint_tools.py
@@ -20,30 +20,83 @@ def register_blueprint_tools(mcp: FastMCP):
         name: str,
         parent_class: str
     ) -> Dict[str, Any]:
-        """Create a new Blueprint class."""
+        """Create a new Blueprint class under /Game/Blueprints.
+
+        Args:
+            name: Asset name of the new Blueprint (e.g. "BP_MyActor")
+            parent_class: Parent class - accepts project C++ classes ("MyActor",
+                "AMyActor"), engine classes ("PlayerStart"), full paths
+                ("/Script/MyGame.MyActor") or other Blueprints ("BP_Base").
+                Fails with an error if the class cannot be resolved (no silent
+                fallback to Actor).
+        """
         # Import inside function to avoid circular imports
         from unreal_mcp_server import get_unreal_connection
-        
+
         try:
             unreal = get_unreal_connection()
             if not unreal:
                 logger.error("Failed to connect to Unreal Engine")
                 return {"success": False, "message": "Failed to connect to Unreal Engine"}
-                
+
             response = unreal.send_command("create_blueprint", {
                 "name": name,
                 "parent_class": parent_class
             })
-            
+
             if not response:
                 logger.error("No response from Unreal Engine")
                 return {"success": False, "message": "No response from Unreal Engine"}
-            
+
             logger.info(f"Blueprint creation response: {response}")
             return response or {}
-            
+
         except Exception as e:
             error_msg = f"Error creating blueprint: {e}"
+            logger.error(error_msg)
+            return {"success": False, "message": error_msg}
+
+    @mcp.tool()
+    def reparent_blueprint(
+        ctx: Context,
+        blueprint_name: str,
+        new_parent_class: str
+    ) -> Dict[str, Any]:
+        """Change the parent class of an existing Blueprint and recompile it.
+
+        Placed instances of the Blueprint are reinstanced in place, so they pick
+        up the components and defaults of the new parent immediately.
+
+        Args:
+            blueprint_name: Name of the Blueprint under /Game/Blueprints
+            new_parent_class: New parent - same formats as create_blueprint's
+                parent_class ("MyActor", "PlayerStart", "/Script/MyGame.MyActor", ...)
+
+        Returns:
+            Dict with old_parent, new_parent and compile status
+        """
+        from unreal_mcp_server import get_unreal_connection
+
+        try:
+            unreal = get_unreal_connection()
+            if not unreal:
+                logger.error("Failed to connect to Unreal Engine")
+                return {"success": False, "message": "Failed to connect to Unreal Engine"}
+
+            response = unreal.send_command("reparent_blueprint", {
+                "blueprint_name": blueprint_name,
+                "new_parent_class": new_parent_class
+            })
+
+            if not response:
+                logger.error("No response from Unreal Engine")
+                return {"success": False, "message": "No response from Unreal Engine"}
+
+            logger.info(f"Reparent blueprint response: {response}")
+            return response
+
+        except Exception as e:
+            error_msg = f"Error reparenting blueprint: {e}"
             logger.error(error_msg)
             return {"success": False, "message": error_msg}
     

--- a/Python/tools/editor_tools.py
+++ b/Python/tools/editor_tools.py
@@ -65,10 +65,13 @@ def register_editor_tools(mcp: FastMCP):
             response = unreal.send_command("find_actors_by_name", {
                 "pattern": pattern
             })
-            
+
             if not response:
                 return []
-                
+
+            # The bridge wraps payloads as {"status": ..., "result": {"actors": [...]}}
+            if "result" in response and "actors" in response["result"]:
+                return response["result"]["actors"]
             return response.get("actors", [])
             
         except Exception as e:

--- a/Python/tools/editor_tools.py
+++ b/Python/tools/editor_tools.py
@@ -84,45 +84,51 @@ def register_editor_tools(mcp: FastMCP):
         name: str,
         type: str,
         location: List[float] = [0.0, 0.0, 0.0],
-        rotation: List[float] = [0.0, 0.0, 0.0]
+        rotation: List[float] = [0.0, 0.0, 0.0],
+        scale: List[float] = [1.0, 1.0, 1.0]
     ) -> Dict[str, Any]:
         """Create a new actor in the current level.
-        
+
         Args:
             ctx: The MCP context
-            name: The name to give the new actor (must be unique)
-            type: The type of actor to create (e.g. StaticMeshActor, PointLight)
+            name: The name to give the new actor (must be unique; names of deleted
+                actors stay blocked until GC/editor restart - pick a fresh name)
+            type: The actor class - built-ins (StaticMeshActor, PointLight, SpotLight,
+                DirectionalLight, CameraActor) or ANY actor class by name/path, e.g.
+                "PlayerStart", "MyActor" or "/Script/MyGame.MyActor"
             location: The [x, y, z] world location to spawn at
             rotation: The [pitch, yaw, roll] rotation in degrees
-            
+            scale: The [x, y, z] world scale
+
         Returns:
             Dict containing the created actor's properties
         """
         from unreal_mcp_server import get_unreal_connection
-        
+
         try:
             unreal = get_unreal_connection()
             if not unreal:
                 logger.error("Failed to connect to Unreal Engine")
                 return {"success": False, "message": "Failed to connect to Unreal Engine"}
-            
+
             # Ensure all parameters are properly formatted
             params = {
                 "name": name,
-                "type": type.upper(),  # Make sure type is uppercase
+                "type": type,
                 "location": location,
-                "rotation": rotation
+                "rotation": rotation,
+                "scale": scale
             }
-            
-            # Validate location and rotation formats
-            for param_name in ["location", "rotation"]:
+
+            # Validate location, rotation and scale formats
+            for param_name in ["location", "rotation", "scale"]:
                 param_value = params[param_name]
                 if not isinstance(param_value, list) or len(param_value) != 3:
                     logger.error(f"Invalid {param_name} format: {param_value}. Must be a list of 3 float values.")
                     return {"success": False, "message": f"Invalid {param_name} format. Must be a list of 3 float values."}
                 # Ensure all values are float
                 params[param_name] = [float(val) for val in param_value]
-            
+
             logger.info(f"Creating actor '{name}' of type '{type}' with params: {params}")
             response = unreal.send_command("spawn_actor", params)
             
@@ -363,10 +369,124 @@ def register_editor_tools(mcp: FastMCP):
             
             logger.info(f"Spawn blueprint actor response: {response}")
             return response
-            
+
         except Exception as e:
             error_msg = f"Error spawning blueprint actor: {e}"
             logger.error(error_msg)
             return {"success": False, "message": error_msg}
+
+    def _send_simple_command(command: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        """Shared plumbing for the smaller editor tools below."""
+        from unreal_mcp_server import get_unreal_connection
+
+        try:
+            unreal = get_unreal_connection()
+            if not unreal:
+                logger.error("Failed to connect to Unreal Engine")
+                return {"success": False, "message": "Failed to connect to Unreal Engine"}
+
+            response = unreal.send_command(command, params)
+            if not response:
+                logger.error(f"No response from Unreal Engine for {command}")
+                return {"success": False, "message": "No response from Unreal Engine"}
+
+            logger.info(f"{command} response: {response}")
+            return response
+
+        except Exception as e:
+            error_msg = f"Error running {command}: {e}"
+            logger.error(error_msg)
+            return {"success": False, "message": error_msg}
+
+    @mcp.tool()
+    def save_all(ctx: Context) -> Dict[str, Any]:
+        """Save all dirty packages (maps AND assets) without any editor prompts.
+
+        Use this after placing actors, creating/reparenting blueprints etc. so the
+        changes reach the .umap/.uasset files on disk (e.g. before a git commit).
+        """
+        return _send_simple_command("save_all", {})
+
+    @mcp.tool()
+    def start_pie(
+        ctx: Context,
+        num_players: int = 1,
+        net_mode: str = "standalone"
+    ) -> Dict[str, Any]:
+        """Start a Play-In-Editor session (starts on the next editor tick).
+
+        Args:
+            num_players: Number of player windows (1-4)
+            net_mode: "standalone", "listen" (Play As Listen Server) or "client"
+
+        The command returns immediately; the session boots within the next editor
+        frames. Watch Saved/Logs/<project>.log for spawn errors, then stop_pie().
+        """
+        return _send_simple_command("start_pie", {
+            "num_players": num_players,
+            "net_mode": net_mode
+        })
+
+    @mcp.tool()
+    def stop_pie(ctx: Context) -> Dict[str, Any]:
+        """End the running Play-In-Editor session (no-op if none is running)."""
+        return _send_simple_command("stop_pie", {})
+
+    @mcp.tool()
+    def exec_console_command(ctx: Context, command: str) -> Dict[str, Any]:
+        """Execute an Unreal console command (cvars, stat, debug toggles, ...).
+
+        Runs in the PIE world when a session is active, otherwise in the editor
+        world. Output goes to the engine log, not the response.
+
+        Args:
+            command: e.g. "cr.StealthDebug 1", "stat fps", "obj gc"
+        """
+        return _send_simple_command("exec_console_command", {"command": command})
+
+    @mcp.tool()
+    def take_screenshot(ctx: Context, filepath: str) -> Dict[str, Any]:
+        """Save a PNG screenshot of the active editor/PIE viewport.
+
+        Args:
+            filepath: Absolute path for the .png (extension added if missing)
+        """
+        return _send_simple_command("take_screenshot", {"filepath": filepath})
+
+    @mcp.tool()
+    def list_assets(
+        ctx: Context,
+        directory: str = "/Game",
+        recursive: bool = True
+    ) -> Dict[str, Any]:
+        """List asset object paths under a content directory.
+
+        Args:
+            directory: Content path like "/Game/Blueprints"
+            recursive: Include subfolders
+        """
+        return _send_simple_command("list_assets", {
+            "directory": directory,
+            "recursive": recursive
+        })
+
+    @mcp.tool()
+    def asset_exists(ctx: Context, asset_path: str) -> Dict[str, Any]:
+        """Check whether an asset exists.
+
+        Args:
+            asset_path: e.g. "/Game/Blueprints/BP_MyActor"
+        """
+        return _send_simple_command("asset_exists", {"asset_path": asset_path})
+
+    @mcp.tool()
+    def delete_asset(ctx: Context, asset_path: str) -> Dict[str, Any]:
+        """Delete an asset from the project. DESTRUCTIVE - referencing actors or
+        assets lose the reference; there is no undo over MCP.
+
+        Args:
+            asset_path: e.g. "/Game/Blueprints/BP_Obsolete"
+        """
+        return _send_simple_command("delete_asset", {"asset_path": asset_path})
 
     logger.info("Editor tools registered successfully")

--- a/Python/unreal_mcp_server.py
+++ b/Python/unreal_mcp_server.py
@@ -26,6 +26,9 @@ logger = logging.getLogger("UnrealMCP")
 # Configuration
 UNREAL_HOST = "127.0.0.1"
 UNREAL_PORT = 55557
+# Commands like save_all, compile_blueprint or reparent_blueprint can easily take
+# longer than the old 5s window - they block until the editor finishes the work.
+UNREAL_RESPONSE_TIMEOUT = 30
 
 class UnrealConnection:
     """Connection to an Unreal Engine instance."""
@@ -81,7 +84,7 @@ class UnrealConnection:
     def receive_full_response(self, sock, buffer_size=4096) -> bytes:
         """Receive a complete response from Unreal, handling chunked data."""
         chunks = []
-        sock.settimeout(5)  # 5 second timeout
+        sock.settimeout(UNREAL_RESPONSE_TIMEOUT)
         try:
             while True:
                 chunk = sock.recv(buffer_size)
@@ -301,19 +304,32 @@ def info():
 
     ## Editor Tools
     ### Viewport and Screenshots
-    - `focus_viewport(target, location, distance, orientation)` - Focus viewport
-    - `take_screenshot(filename, show_ui, resolution)` - Capture screenshots
+    - `take_screenshot(filepath)` - Save a PNG of the active editor/PIE viewport
+
+    ### Session and Level
+    - `save_all()` - Save all dirty maps and assets without prompts
+    - `start_pie(num_players=1, net_mode="standalone"|"listen"|"client")` - Start Play-In-Editor
+    - `stop_pie()` - End the PIE session
+    - `exec_console_command(command)` - Run a console command (cvars, stat, debug toggles)
+
+    ### Asset Management
+    - `list_assets(directory="/Game", recursive=True)` - List asset paths
+    - `asset_exists(asset_path)` - Check if an asset exists
+    - `delete_asset(asset_path)` - Delete an asset (destructive!)
 
     ### Actor Management
     - `get_actors_in_level()` - List all actors in current level
-    - `find_actors_by_name(pattern)` - Find actors by name pattern
+    - `find_actors_by_name(pattern)` - Find actors by name or label pattern
     - `spawn_actor(name, type, location=[0,0,0], rotation=[0,0,0], scale=[1,1,1])` - Create actors
-    - `delete_actor(name)` - Remove actors
+      (type: built-ins like StaticMeshActor/PointLight or ANY class: "PlayerStart", "MyActor", "/Script/MyGame.MyActor")
+    - `delete_actor(name)` - Remove actors (the name stays blocked until GC/editor restart!)
     - `set_actor_transform(name, location, rotation, scale)` - Modify actor transform
     - `get_actor_properties(name)` - Get actor properties
-    
+
     ## Blueprint Management
     - `create_blueprint(name, parent_class)` - Create new Blueprint classes
+      (parent_class resolves project C++ classes, engine classes and paths; errors instead of falling back to Actor)
+    - `reparent_blueprint(blueprint_name, new_parent_class)` - Change a Blueprint's parent class and recompile
     - `add_component_to_blueprint(blueprint_name, component_type, component_name)` - Add components
     - `set_static_mesh_properties(blueprint_name, component_name, static_mesh)` - Configure meshes
     - `set_physics_properties(blueprint_name, component_name)` - Configure physics


### PR DESCRIPTION
> **Note:** Builds on #60 (the first four commits here are that PR's bugfixes — `reparent_blueprint` and the generic spawn support use the `ResolveClassByName` resolver introduced there). Once #60 is merged, this PR shows only the feature commits.

## Summary

Adds the editor-session and asset-management commands we found missing while driving the editor from an MCP client, plus the matching Python tools and documentation.

## New commands (bridge + Python tools)

**Session / level:**
- `save_all` — silently save all dirty packages (maps + assets). Uses fast-save so no source-control modal can block the game thread past the client timeout.
- `start_pie` / `stop_pie` — start/stop a Play In Editor session, with optional `num_players` (1–4) and `net_mode` (`standalone`/`listen`/`client`). Lets an agent actually playtest what it just built.
- `exec_console_command` — run a console command (`stat fps`, `slomo 0.5`, custom cheats, …) in the PIE world when one is active, otherwise in the editor world.

**Assets:**
- `list_assets` — list asset paths under a directory (recursive by default).
- `asset_exists` — cheap existence probe so agents stop guessing paths.
- `delete_asset` — delete a single asset, with a clear error when it does not exist.

**Blueprints:**
- `reparent_blueprint` — change a blueprint's parent class via `UBlueprintEditorLibrary::ReparentBlueprint` plus a recompile so placed instances get reinstanced. Refuses reparenting onto a child of the blueprint's own generated class, and reports old/new parent and the compile status in the response.

## Improvements to existing tools

- `spawn_actor` now accepts **any** actor class — project C++ classes, Blueprint classes, full `/Script/Module.Class` paths — through the shared class resolver, in addition to the built-in shortcuts (StaticMeshActor, lights, camera). Non-actor, abstract and deprecated classes are rejected with a clear error. The Python tool also drops a bogus `.upper()` call on the type (class names are case-sensitive) and gains the previously missing `scale` parameter. This overlaps with #53, which adds the same capability via a `FindFirstObject` fallback — consider this part an alternative that routes the lookup through the shared strict resolver (also covers Blueprint classes and `/Script` paths, and rejects abstract/deprecated/non-actor classes).
- Python response timeout raised from 5 s to 30 s: compiles, saves and PIE startup routinely block the bridge longer than 5 s and produced spurious timeouts — this should also address the "Timeout receiving Unreal response" symptom reported in #15.
- `take_screenshot` is now exposed as a Python tool (the bridge command already existed), and the `info()` prompt overview documents all tools.

## How tested

Built and used daily against **UE 5.8** in our own game project with an MCP client (Claude) driving the editor end-to-end: create blueprint → add components → reparent onto a project C++ class → save_all → start_pie → exec console commands during play → stop_pie, plus list/exists/delete round-trips on generated assets. Reparenting was verified to reinstance placed actors and to report compile warnings/errors in the response instead of failing silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
